### PR TITLE
docs: fix rtfd build badge so it shows the real status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 .. image:: https://img.shields.io/travis/reanahub/reana-workflow-monitor.svg
          :target: https://travis-ci.org/reanahub/reana-workflow-monitor
 
-.. image:: https://readthedocs.org/projects/docs/badge/?version=latest
+.. image:: https://readthedocs.org/projects/reana-workflow-monitor/badge/?version=latest
          :target: https://reana-workflow-monitor.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/coveralls/reanahub/reana-workflow-monitor.svg


### PR DESCRIPTION
* Closes reanahub/reana#162

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>